### PR TITLE
Track hallucination effect count

### DIFF
--- a/extension/ui/hud.js
+++ b/extension/ui/hud.js
@@ -303,6 +303,7 @@ function resetSessionStartTime() {
   sessionStartTime = Date.now();
   localStorage.setItem('sessionStartTime', sessionStartTime);
   updateElapsedTimeDisplay(0);
+  resetEffectCount();
 }
 
 // 8. Exported functions (to connect data later)


### PR DESCRIPTION
## Summary
- reset effect count when session resets so HUD counter starts fresh

## Testing
- `node --check extension/ui/hud.js`


------
https://chatgpt.com/codex/tasks/task_e_684f5b89b4e4832fb3144fd2b6aaf15c