### PR TITLE
Add effect pack system with dynamic HUD selection

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,0 +1,84 @@
+// Load effect packs and integrate with HUD
+let effectPacks = {};
+let effectPackList = [];
+let currentEffectPack = localStorage.getItem('currentEffectPack') || '';
+
+async function loadEffectPacks() {
+  const packNames = ['cyberpunk', 'dreamcore', 'industrial'];
+  for (let name of packNames) {
+    try {
+      const resp = await fetch(`effect-packs/${name}.json`);
+      if (resp.ok) {
+        const pack = await resp.json();
+        effectPacks[pack.name] = pack;
+        effectPackList.push(pack.name);
+      }
+    } catch (err) {
+      console.error('Failed to load pack', name, err);
+    }
+  }
+
+  if (!currentEffectPack || !effectPacks[currentEffectPack]) {
+    currentEffectPack = effectPackList[Math.floor(Math.random() * effectPackList.length)];
+    localStorage.setItem('currentEffectPack', currentEffectPack);
+  }
+
+  populatePackDropdown();
+  updateEffectPackHUD(currentEffectPack);
+}
+
+// Create dropdown container
+const packDiv = document.createElement('div');
+packDiv.id = 'uh-hud-pack-select';
+packDiv.style.margin = '10px 0';
+packDiv.innerHTML = `
+  <label for="uh-hud-pack" style="font-weight:bold; margin-right:6px;">Pack:</label>
+  <select id="uh-hud-pack"></select>
+  <span id="uh-hud-pack-label" style="margin-left:10px; font-weight:bold;">${currentEffectPack}</span>
+`;
+
+function populatePackDropdown() {
+  const sel = document.getElementById('uh-hud-pack');
+  sel.innerHTML = '';
+  effectPackList.forEach(name => {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    sel.appendChild(opt);
+  });
+  sel.value = currentEffectPack;
+}
+
+function updateEffectPackHUD(packName) {
+  const label = document.getElementById('uh-hud-pack-label');
+  if (label) label.textContent = packName;
+  const sel = document.getElementById('uh-hud-pack');
+  if (sel) sel.value = packName;
+  window.currentEffectPack = packName;
+}
+
+function handlePackChange(e) {
+  currentEffectPack = e.target.value;
+  localStorage.setItem('currentEffectPack', currentEffectPack);
+  updateEffectPackHUD(currentEffectPack);
+  if (window.__uhHUDPackCB) window.__uhHUDPackCB(currentEffectPack);
+}
+
+// Wait for HUD panel then append dropdown and load packs
+window.addEventListener('DOMContentLoaded', () => {
+  const panel = document.getElementById('uh-hud-panel');
+  if (panel) {
+    panel.appendChild(packDiv);
+    document.getElementById('uh-hud-pack').onchange = handlePackChange;
+    loadEffectPacks();
+  }
+});
+
+// Example helper to get effects for current mood
+function getEffectsForMood(mood) {
+  const pack = effectPacks[currentEffectPack];
+  if (pack && pack.moods[mood]) {
+    return pack.moods[mood];
+  }
+  return [];
+}

--- a/effect-packs/cyberpunk.json
+++ b/effect-packs/cyberpunk.json
@@ -1,0 +1,8 @@
+{
+  "name": "Cyberpunk",
+  "moods": {
+    "low": ["soft-glow", "flicker-lines"],
+    "medium": ["static-drift", "scanline-burst"],
+    "high": ["neon-bloom", "electric-smear"]
+  }
+}

--- a/effect-packs/dreamcore.json
+++ b/effect-packs/dreamcore.json
@@ -1,0 +1,8 @@
+{
+  "name": "Dreamcore",
+  "moods": {
+    "low": ["hazy-fade", "pastel-flow"],
+    "medium": ["echo-swirl", "deep-mist"],
+    "high": ["vivid-flash", "liquid-shift"]
+  }
+}

--- a/effect-packs/industrial.json
+++ b/effect-packs/industrial.json
@@ -1,0 +1,8 @@
+{
+  "name": "Industrial",
+  "moods": {
+    "low": ["rust-grain", "smoke-overlay"],
+    "medium": ["gear-spark", "steam-bleed"],
+    "high": ["metal-clang", "factory-blast"]
+  }
+}

--- a/extension/ui/hud.js
+++ b/extension/ui/hud.js
@@ -16,7 +16,7 @@ window.stepCount = stepCount;
 let effectCount = Number(localStorage.getItem('effectCount') || 0);
 
 // Restore effect pack selection or set default
-let currentEffectPack = localStorage.getItem('currentEffectPack') || 'urban';
+let currentEffectPack = localStorage.getItem('currentEffectPack') || '';
 window.currentEffectPack = currentEffectPack;
 
 // Restore or initialize session start time
@@ -83,15 +83,6 @@ hudPanel.innerHTML = `
     <b>BPM:</b> <span id="uh-hud-bpm-val">120</span><br>
     <b>Energy:</b> <span id="uh-hud-energy-val">Medium</span>
   </div>
-  <div>
-    <b>Hallucination Pack:</b>
-    <select id="uh-hud-pack">
-      <option value="urban">Urban</option>
-      <option value="cyberpunk">Cyberpunk</option>
-      <option value="nature">Nature</option>
-      <option value="random">Random</option>
-    </select>
-  </div>
 `;
 
 // Add Mood dropdown to HUD
@@ -110,18 +101,6 @@ moodDiv.innerHTML = `
 `;
 
 hudPanel.appendChild(moodDiv);
-
-// Setup hallucination pack select
-const packSelect = document.getElementById('uh-hud-pack');
-packSelect.value = currentEffectPack;
-packSelect.onchange = e => {
-  currentEffectPack = e.target.value;
-  window.currentEffectPack = currentEffectPack;
-  localStorage.setItem('currentEffectPack', currentEffectPack);
-  if (typeof window.__uhHUDPackCB === 'function') {
-    window.__uhHUDPackCB(currentEffectPack);
-  }
-};
 
 // Set initial mood and handler
 const moodSelect = document.getElementById('uh-hud-mood-select');
@@ -364,7 +343,7 @@ function resetSession() {
   stepCount = 0;
   effectCount = 0;
   sessionMood = 'medium';
-  currentEffectPack = 'urban';
+  currentEffectPack = localStorage.getItem('currentEffectPack') || currentEffectPack || 'urban';
   sessionStartTime = Date.now();
 
   window.stepCount = stepCount;
@@ -382,7 +361,12 @@ function resetSession() {
   document.getElementById('uh-hud-mood-select').value = sessionMood;
   document.getElementById('uh-hud-mood-label').textContent =
     'Mood: ' + sessionMood.charAt(0).toUpperCase() + sessionMood.slice(1);
-  document.getElementById('uh-hud-pack').value = currentEffectPack;
+  if (typeof window.updateEffectPackHUD === 'function') {
+    window.updateEffectPackHUD(currentEffectPack);
+  } else {
+    const sel = document.getElementById('uh-hud-pack');
+    if (sel) sel.value = currentEffectPack;
+  }
   updateElapsedTimeDisplay(0);
   updateEffectCountHUD(effectCount);
 }
@@ -396,7 +380,12 @@ window.uhHUD = {
   },
   setInputSource: src => document.getElementById('uh-hud-input').textContent = src,
   setPack: pack => {
-    document.getElementById('uh-hud-pack').value = pack;
+    if (typeof window.updateEffectPackHUD === 'function') {
+      window.updateEffectPackHUD(pack);
+    } else {
+      const sel = document.getElementById('uh-hud-pack');
+      if (sel) sel.value = pack;
+    }
     currentEffectPack = pack;
     window.currentEffectPack = pack;
     localStorage.setItem('currentEffectPack', pack);


### PR DESCRIPTION
## Summary
- add `effect-packs/` folder with example packs
- load packs and populate dropdown in new `content.js`
- update `hud.js` to defer pack handling to new script

## Testing
- `node -e "const fs=require('fs'); console.log('packs', fs.readdirSync('effect-packs'));"`

------
https://chatgpt.com/codex/tasks/task_e_684f660bbeac832faa1008251f525e8b