### PR TITLE
Load effect packs dynamically

### DIFF
--- a/effect-packs/cyberpunk.json
+++ b/effect-packs/cyberpunk.json
@@ -4,5 +4,10 @@
     "low": ["soft-glow", "flicker-lines"],
     "medium": ["static-drift", "scanline-burst"],
     "high": ["neon-bloom", "electric-smear"]
+  },
+  "zones": {
+    "top-left": "scanline-burst",
+    "center": "neon-bloom",
+    "bottom-right": "electric-smear"
   }
 }

--- a/effect-packs/dreamcore.json
+++ b/effect-packs/dreamcore.json
@@ -4,5 +4,9 @@
     "low": ["hazy-fade", "pastel-flow"],
     "medium": ["echo-swirl", "deep-mist"],
     "high": ["vivid-flash", "liquid-shift"]
+  },
+  "zones": {
+    "top-right": "deep-mist",
+    "center": "vivid-flash"
   }
 }

--- a/effect-packs/industrial.json
+++ b/effect-packs/industrial.json
@@ -4,5 +4,9 @@
     "low": ["rust-grain", "smoke-overlay"],
     "medium": ["gear-spark", "steam-bleed"],
     "high": ["metal-clang", "factory-blast"]
+  },
+  "zones": {
+    "bottom-left": "rust-grain",
+    "center": "factory-blast"
   }
 }


### PR DESCRIPTION
## Summary
- update JSON files for effect packs with zone info
- fetch JSON packs dynamically in `content.js`
- keep current pack mapping when selecting from HUD

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f67a0c7f4832f86c24d19d3150a6b