### PR TITLE
Enable zone-based effect assignment and filtering

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,6 +1,7 @@
 // Manage effect packs loaded from JSON files
 let moodEffectMap = {};
 let zoneEffectMap = {};
+window.zoneEffectMap = zoneEffectMap;
 let effectPacks = {};
 let currentEffectPack = localStorage.getItem('currentEffectPack') || 'cyberpunk';
 
@@ -21,6 +22,7 @@ async function loadEffectPack(packName) {
   effectPacks[packName] = pack;
   moodEffectMap = pack.moods || {};
   zoneEffectMap = pack.zones || {};
+  window.zoneEffectMap = zoneEffectMap;
 
   updateEffectPackHUD(pack.name);
 
@@ -71,6 +73,51 @@ function getEffectsForMood(mood) {
 
 function getZoneEffect(zone) {
   return zoneEffectMap[zone];
+}
+
+// --- Zone-based effect selection helpers ---
+function pickZone() {
+  const names = Object.keys(zoneEffectMap);
+  if (!names.length) return null;
+  return names[Math.floor(Math.random() * names.length)];
+}
+
+function pickEffectForZone(zone) {
+  const effects = zoneEffectMap[zone] || [];
+  if (!effects.length) return null;
+  return effects[Math.floor(Math.random() * effects.length)];
+}
+
+function triggerZoneEffect() {
+  const zone = pickZone();
+  if (!zone) return;
+  const effect = pickEffectForZone(zone);
+  if (!effect) return;
+
+  const overlay = document.createElement('div');
+  overlay.className = `uh-effect-zone-${zone}`;
+  Object.assign(overlay.style, getZoneStyles(zone), {
+    pointerEvents: 'none',
+    zIndex: 99999,
+    border: '3px solid #19e22e',
+    boxShadow: '0 0 16px 8px #19e22e77',
+    transition: 'opacity 0.6s'
+  });
+
+  overlay.innerHTML = `<span style="font-size:1.2em;color:#19e22e;background:rgba(24,24,24,0.6);padding:2px 8px;border-radius:8px;position:absolute;bottom:6px;right:12px;">${effect}</span>`;
+
+  document.body.appendChild(overlay);
+
+  setTimeout(() => { overlay.style.opacity = 0; }, 1300);
+  setTimeout(() => { overlay.remove(); }, 1800);
+
+  document.getElementById('uh-hud-effect-zone')?.remove();
+  const hudDiv = document.createElement('div');
+  hudDiv.id = 'uh-hud-effect-zone';
+  hudDiv.style.margin = '10px 0';
+  hudDiv.style.fontWeight = 'bold';
+  hudDiv.innerHTML = `Effect: <span style="color:#19e22e;">${effect}</span> | Zone: <span style="color:#1982e2;">${zone}</span>`;
+  document.getElementById('uh-hud-panel')?.appendChild(hudDiv);
 }
 
 // --- Screen zone definitions ---
@@ -130,3 +177,4 @@ window.getZoneStyles = getZoneStyles;
 window.showDebugZones = showDebugZones;
 window.removeDebugZones = removeDebugZones;
 window.createZoneOverlay = createZoneOverlay;
+window.triggerZoneEffect = triggerZoneEffect;

--- a/effect-packs/cyberpunk.json
+++ b/effect-packs/cyberpunk.json
@@ -6,8 +6,8 @@
     "high": ["neon-bloom", "electric-smear"]
   },
   "zones": {
-    "top-left": "scanline-burst",
-    "center": "neon-bloom",
-    "bottom-right": "electric-smear"
+    "top-left": ["scanline-burst"],
+    "center": ["neon-bloom"],
+    "bottom-right": ["electric-smear"]
   }
 }

--- a/effect-packs/dreamcore.json
+++ b/effect-packs/dreamcore.json
@@ -6,7 +6,7 @@
     "high": ["vivid-flash", "liquid-shift"]
   },
   "zones": {
-    "top-right": "deep-mist",
-    "center": "vivid-flash"
+    "top-right": ["deep-mist"],
+    "center": ["vivid-flash"]
   }
 }

--- a/effect-packs/industrial.json
+++ b/effect-packs/industrial.json
@@ -6,7 +6,7 @@
     "high": ["metal-clang", "factory-blast"]
   },
   "zones": {
-    "bottom-left": "rust-grain",
-    "center": "factory-blast"
+    "bottom-left": ["rust-grain"],
+    "center": ["factory-blast"]
   }
 }

--- a/extension/ui/hud.js
+++ b/extension/ui/hud.js
@@ -373,9 +373,9 @@ startEffectInterval();
 
 function triggerEffect(...args) {
   if (hallucinationsEnabled) {
-    // ... existing effect code here ...
-    // Mood can influence intensity, visuals, etc.
-    // sessionMood will be 'low', 'medium', or 'high'
+    if (typeof window.triggerZoneEffect === 'function') {
+      window.triggerZoneEffect();
+    }
     effectCount++;
     updateEffectCountHUD(effectCount);
   }


### PR DESCRIPTION
## Summary
- support arrays of effects per zone in all effect packs
- implement zone-aware effect logic in `content.js`
- expose `triggerZoneEffect` globally
- call zone-based effects from the HUD's trigger function

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684f6b10c180832fb18b27afdc6d6264