### PR TITLE
Add WebSocket step input

### DIFF
--- a/fake_step_server.py
+++ b/fake_step_server.py
@@ -1,0 +1,17 @@
+import asyncio
+import websockets
+import json
+
+async def step_server(websocket):
+    while True:
+        await asyncio.sleep(1.5)
+        await websocket.send(json.dumps({"steps": 1}))
+
+async def main():
+    async with websockets.serve(step_server, "localhost", 6789):
+        await asyncio.Future()
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+


### PR DESCRIPTION
## Summary
- connect HUD to local step server via WebSocket
- update HUD to show Fake Server as input source
- stop timer-based effects so steps trigger visuals
- provide a simple Python WebSocket server for testing

## Testing
- `python - <<'PY'
import asyncio, websockets, json
async def test():
    uri = 'ws://localhost:6789'
    async with websockets.connect(uri) as ws:
        for i in range(3):
            print(await ws.recv())
asyncio.run(test())
PY`


------
https://chatgpt.com/codex/tasks/task_e_684f6ea784b0832f9946e701cab73b18