### PR TITLE
Disable audio triggers when simple timed mode is active

### DIFF
--- a/content.js
+++ b/content.js
@@ -5,6 +5,10 @@ window.zoneEffectMap = zoneEffectMap;
 let effectPacks = {};
 let currentEffectPack = localStorage.getItem('currentEffectPack') || 'cyberpunk';
 
+// Global toggle to enable/disable audio-driven triggers
+let audioTriggersEnabled = true;
+window.audioTriggersEnabled = audioTriggersEnabled;
+
 function updateEffectPackHUD(packName) {
   const label = document.getElementById('uh-hud-pack-label');
   if (label) label.textContent = packName;
@@ -755,12 +759,14 @@ function addJustLetMeRunToggle() {
 
   // Handler: enable/disable simple timed mode
   checkbox.addEventListener('change', (e) => {
+    audioTriggersEnabled = !e.target.checked; // Disable if checked
+    window.audioTriggersEnabled = audioTriggersEnabled;
     if (e.target.checked) {
-      console.log('Simple Timed Mode: ON');
-      // TODO: activate simple timed mode (disable hallucinations, etc.)
+      console.log("Simple Timed Mode: ON (Audio triggers paused)");
+      // Optionally, pause/stop any ongoing audio-triggered intervals or effects here
     } else {
-      console.log('Simple Timed Mode: OFF');
-      // TODO: deactivate simple timed mode
+      console.log("Simple Timed Mode: OFF (Audio triggers resumed)");
+      // Optionally, resume audio triggers
     }
   });
 

--- a/loudness_sim.js
+++ b/loudness_sim.js
@@ -24,6 +24,10 @@ function getSimulatedLoudness() {
 
 // Trigger hallucination effect
 function triggerLoudnessEffect() {
+  if (typeof window.audioTriggersEnabled !== 'undefined' && !window.audioTriggersEnabled) {
+    // Skip trigger if audio-driven effects are disabled
+    return;
+  }
   if (typeof window.triggerEffect === 'function') {
     window.triggerEffect();
   } else {


### PR DESCRIPTION
## Summary
- add `audioTriggersEnabled` global toggle
- pause/resume audio triggers when "Just Let Me Run" is switched
- respect the flag in `loudness_sim.js`

## Testing
- `python -m py_compile audio_tracker_server.py fake_step_server.py`
- `node -c content.js`
- `node -c loudness_sim.js`


------
https://chatgpt.com/codex/tasks/task_e_68508d14c2a0832f8f55cb0e1231ea77