### PR TITLE
Persist and highlight selected tag

### DIFF
--- a/content.js
+++ b/content.js
@@ -801,18 +801,31 @@ function addTagButtons(tags, onTagClick) {
   tagWrap.id = 'hud-tag-buttons';
   tagWrap.style.marginTop = '12px';
 
+  // Get saved tag from localStorage
+  const savedTag = localStorage.getItem('selectedTag');
+
   tags.forEach(tag => {
     const btn = document.createElement('button');
     btn.textContent = tag;
     btn.style.margin = "0 6px 6px 0";
     btn.style.padding = "4px 14px";
-    btn.style.background = "#353535";
+    btn.style.background = (tag === savedTag) ? "#29a19c" : "#353535";
     btn.style.color = "#fff";
     btn.style.border = "none";
     btn.style.borderRadius = "6px";
     btn.style.fontSize = "16px";
     btn.style.cursor = "pointer";
-    btn.addEventListener('click', () => onTagClick(tag));
+    btn.addEventListener('click', () => {
+      // Save tag to localStorage
+      localStorage.setItem('selectedTag', tag);
+
+      // Update button styles to show selection
+      Array.from(tagWrap.children).forEach(b =>
+        b.style.background = (b.textContent === tag) ? "#29a19c" : "#353535"
+      );
+
+      onTagClick(tag);
+    });
     tagWrap.appendChild(btn);
   });
 
@@ -822,7 +835,7 @@ function addTagButtons(tags, onTagClick) {
 addTagButtons(
   ["Urban", "Nature", "Dreamcore", "Glide", "Ambient", "Rare"],
   (tag) => {
-    console.log("Tag clicked:", tag);
+    console.log("Tag clicked & saved:", tag);
     // TODO: Filter playlists/assets/spawn effects based on tag
   }
 );


### PR DESCRIPTION
## Summary
- remember last selected tag in localStorage
- highlight the active tag button after reload

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68508f014f14832f9a72cc553e319311